### PR TITLE
Update GO install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ brew install asciicat
 
 Or using Go:
 ```
-go get github.com/alfg/asciicat
+go install github.com/alfg/asciicat@latest
 ```
 
 ## Usage


### PR DESCRIPTION
```
❯ go get github.com/alfg/asciicat
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```